### PR TITLE
refactor(upgrade): remove unnecessary renderPullSecrets

### DIFF
--- a/templates/upgrade.yml
+++ b/templates/upgrade.yml
@@ -19,7 +19,6 @@ spec:
         - name: stream-upgrade
           image: {{ include "common.images.image" (dict "imageRoot" .Values.upgrade.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.upgrade.image.pullPolicy | default "IfNotPresent" | quote }}
-          {{- include "common.images.renderPullSecrets" (dict "images" (list .Values.upgrade.image) "context" $) | nindent 10 }}
           args: [
               "-y",
               "-m", "$(MONGODB_URI)",


### PR DESCRIPTION
The `common.images.renderPullSecrets` line 22 is a duplicate in a wrong place of the `common.images.renderPullSecrets` line 9