### PR TITLE
chore: add option to set custom annotations and labels to deployment

### DIFF
--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -6,6 +6,18 @@ metadata:
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
+  {{- if .Values.deploymentLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.deploymentLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if or .Values.commonAnnotations .Values.deploymentAnnotations }}
+  annotations:
+  {{- if .Values.deploymentAnnotations }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.deploymentAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- if not .Values.horizontalAutoscaler.enabled }}

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -4,6 +4,68 @@ templates:
   - deployment.yml
   - hpa.yml
 tests:
+  - it: should omit deployment annotations by default
+    template: deployment.yml
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: metadata.annotations
+
+  - it: should render deployment annotations when commonAnnotations is specified
+    template: deployment.yml
+    set:
+      commonAnnotations:
+        test: value
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.annotations
+          value:
+            test: value
+
+  - it: should render deployment annotations when deploymentAnnotations is specified
+    template: deployment.yml
+    set:
+      deploymentAnnotations:
+        test: value
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.annotations
+          value:
+            test: value
+
+  - it: should render deployment annotations when commonAnnotations and deploymentAnnotations are specified
+    template: deployment.yml
+    set:
+      commonAnnotations:
+        value: test
+      deploymentAnnotations:
+        test: value
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.annotations
+          value:
+            value: test
+            test: value
+
+  - it: should render deployment labels when deploymentLabels is specified
+    template: deployment.yml
+    set:
+      deploymentLabels:
+        test: value
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.labels["test"]
+          value: value
+
   - it: should render deployment replicas from replicas when autoscaling is disabled
     template: deployment.yml
     set:

--- a/values.yaml
+++ b/values.yaml
@@ -75,6 +75,14 @@ image:
 updateStrategy:
   type: Recreate
 
+## @param deploymentAnnotations Annotations to add to the deployment object
+##
+deploymentAnnotations: {}
+
+## @param deploymentAnnotations Annotations to add to the deployment object
+##
+deploymentLabels: {}
+
 ## @param priorityClassName Stream pod priority class name
 ##
 priorityClassName: ""


### PR DESCRIPTION
Add support for configuring custom annotations and labels on the Deployment resource. This introduces additional template options, reusing the same keys as defined in the Horizon templates to ensure consistency.