### PR TITLE
feat: add prometheus service monitor template

### DIFF
--- a/templates/monitor.yml
+++ b/templates/monitor.yml
@@ -1,0 +1,22 @@
+{{ if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.monitoring.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "stream.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - port: kamon
+      path: /metrics
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+{{ end }}

--- a/tests/monitor_test.yaml
+++ b/tests/monitor_test.yaml
@@ -1,0 +1,109 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: monitoring features
+templates:
+  - monitor.yml
+tests:
+  - it: should not render a ServiceMonitor when the monitoring.coreos.com/v1 API is unavailable
+    template: monitor.yml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a ServiceMonitor by default when the API is available
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    template: monitor.yml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceMonitor
+
+  - it: should not render a ServiceMonitor when monitoring.enabled is false
+    set:
+      monitoring.enabled: false
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    template: monitor.yml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a ServiceMonitor when monitoring.enabled is true and the API is available
+    set:
+      monitoring.enabled: true
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    template: monitor.yml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceMonitor
+      - isAPIVersion:
+          of: monitoring.coreos.com/v1
+      - equal:
+          path: spec.endpoints
+          value:
+            - port: kamon
+              path: /metrics
+      - equal:
+          path: spec.namespaceSelector.matchNames
+          value:
+            - NAMESPACE
+
+  - it: should not render a ServiceMonitor when monitoring.enabled is true but the API is unavailable
+    set:
+      monitoring.enabled: true
+    template: monitor.yml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should omit ServiceMonitor annotations by default
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    template: monitor.yml
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - notExists:
+          path: metadata.annotations
+
+  - it: should render ServiceMonitor annotations when commonAnnotations is specified
+    set:
+      commonAnnotations:
+        test: value
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    template: monitor.yml
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: metadata.annotations
+          value:
+            test: value
+
+  - it: should render ServiceMonitor labels in addition to standard labels when commonLabels is specified
+    set:
+      commonLabels:
+        test: value
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    template: monitor.yml
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: metadata.labels["test"]
+          value: value
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm

--- a/values.yaml
+++ b/values.yaml
@@ -393,6 +393,10 @@ ingress:
   ##             name: http
   ##
   extraRules: []
+## Prometheus monitor configuration
+monitoring:
+  ## Enable the creation of a ServiceMonitor object for Stream if the cluster has the monitoring.coreos.com/v1 capability
+  enabled: true
 ## Configure the Play secret for the Stream instance.
 ## As this is used for cryptographic purposes, it should be fetched
 ## from the environment.


### PR DESCRIPTION
Render a ServiceMonitor scraping the kamon metrics endpoint when the cluster has the monitoring.coreos.com/v1 CRD available.