### PR TITLE
feat: add enable service links support to deployment

### DIFF
--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -228,6 +228,7 @@ spec:
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy | quote }}
       {{- end }}
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) | nindent 6 }}
       volumes:
         - name: {{ .Release.Name }}-etc

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -171,3 +171,23 @@ tests:
       - equal:
           path: spec.template.spec.dnsPolicy
           value: ClusterFirstWithHostNet
+
+  - it: should render enableServiceLinks by default
+    template: deployment.yml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.enableServiceLinks
+          value: true
+
+  - it: should render enableServiceLinks when disabled
+    template: deployment.yml
+    set:
+      enableServiceLinks: false
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.enableServiceLinks
+          value: false

--- a/values.yaml
+++ b/values.yaml
@@ -292,6 +292,10 @@ dnsConfig: {}
 ## Pod's DNS Policy
 ## @ref https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
 dnsPolicy: ClusterFirst
+## Whether information about services should be injected into pod's environment variable
+##
+## @ref https://kubernetes.io/docs/tutorials/services/connect-applications-service/#accessing-the-service
+enableServiceLinks: true
 ## Service configuration
 service:
   ## Kubernetes service type


### PR DESCRIPTION
Allow disabling injection of service info into pod environment variables via .Values.enableServiceLinks (default: true).